### PR TITLE
Explicitly specify azure budget end date

### DIFF
--- a/infra/tfmodules/budget/main.tf
+++ b/infra/tfmodules/budget/main.tf
@@ -5,6 +5,7 @@ resource "azurerm_consumption_budget_subscription" "budget" {
   time_grain      = "Monthly"
   time_period {
     start_date = "2023-03-01T00:00:00Z"
+    end_date = "2030-03-01T00:00:00Z"
   }
   notification {
     enabled        = true


### PR DESCRIPTION
For some reason, even though the TF doc says if left blank it will be 10
years, the actual value from Azure portal is same as start date
